### PR TITLE
Add rules rmdup and bam_index, working version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 fastq/
+.snakemake/
+result/

--- a/Snakefile
+++ b/Snakefile
@@ -22,7 +22,7 @@ GENOME_FASTA_FILE = os.path.basename(config["refs"]["genome_url"])
 ##############
 wildcard_constraints:
 
-    sample="[A-Za-z0-9]+"
+sample="[A-Za-z0-9]+"
 
 ##############
 # Desired output
@@ -36,8 +36,6 @@ FASTQC_REPORTS = expand(RESULT_DIR + "fastqc/{sample}_{pair}_fastqc.zip", sample
 ################
 rule all:
     input:
-
-        expand(RESULT_DIR + "mapped/{sample}.sorted.bam", sample=config["samples"]),
         BAM_INDEX,
         BAM_RMDUP,
         FASTQC_REPORTS

--- a/Snakefile
+++ b/Snakefile
@@ -138,7 +138,7 @@ rule rmdup:
         RESULT_DIR + "mapped/{sample}.sorted.bam"
     output:
         RESULT_DIR + "mapped/{sample}.sorted.rmdup.bam"
-    message: "Removing duplicate from file {wilcards.sample}"    
+    message: "Removing duplicate from file {input}"
     shell:
         "samtools rmdup {input} {output}"                       #samtools manual says "This command is obsolete. Use markdup instead."
 


### PR DESCRIPTION
Add rule rmdup and rule bam_index.

**Rule rmdup**: Remove potential PCR duplicates: if multiple read pairs have identical external coordinates, only retain the pair with highest mapping quality. Samtools manuals says "This command is obsolete. Use markdup instead."

**Rule bam_index** : Create indexed bam files for quick access of the .rmdup.sorted.bam files.